### PR TITLE
Create type stubs for `ldr_tools_py`

### DIFF
--- a/ldr_tools_blender/importldr.py
+++ b/ldr_tools_blender/importldr.py
@@ -2,6 +2,7 @@ import bpy
 import numpy as np
 import mathutils
 import math
+import typing
 
 from bpy.types import (
     NodesModifier,
@@ -15,10 +16,12 @@ from bpy.types import (
     FunctionNodeAxisAngleToRotation,
 )
 
-# TODO: Create a pyi type stub file?
-from . import ldr_tools_py
-
-from .ldr_tools_py import LDrawNode, LDrawGeometry, LDrawColor, GeometrySettings
+if typing.TYPE_CHECKING:
+    import ldr_tools_py
+    from ldr_tools_py import LDrawNode, LDrawGeometry, LDrawColor, GeometrySettings
+else:
+    from . import ldr_tools_py
+    from .ldr_tools_py import LDrawNode, LDrawGeometry, LDrawColor, GeometrySettings
 
 from .material import get_material
 

--- a/ldr_tools_blender/material.py
+++ b/ldr_tools_blender/material.py
@@ -1,7 +1,11 @@
+import typing
 from typing import Callable, TypeVar
-from dataclasses import dataclass
 
-from .ldr_tools_py import LDrawColor
+if typing.TYPE_CHECKING:
+    from ldr_tools_py import LDrawColor
+else:
+    from .ldr_tools_py import LDrawColor
+
 from .colors import rgb_peeron_by_code, rgb_ldr_tools_by_code
 from .node_dsl import NodeGraph, GraphNode, NodeInput
 

--- a/ldr_tools_blender/operator.py
+++ b/ldr_tools_blender/operator.py
@@ -3,11 +3,16 @@ import json
 import bpy
 from bpy.props import StringProperty, EnumProperty, BoolProperty
 from bpy_extras.io_utils import ImportHelper
+import typing
 from typing import Any
 import platform
 
 from .importldr import import_ldraw
-from . import ldr_tools_py
+
+if typing.TYPE_CHECKING:
+    import ldr_tools_py
+else:
+    from . import ldr_tools_py
 
 
 def find_ldraw_library() -> str:

--- a/ldr_tools_py/__init__.py
+++ b/ldr_tools_py/__init__.py
@@ -1,0 +1,1 @@
+from .ldr_tools_py import *

--- a/ldr_tools_py/ldr_tools_py.pyi
+++ b/ldr_tools_py/ldr_tools_py.pyi
@@ -1,8 +1,9 @@
 from .stub_helpers import (
     UIntArray,
     FloatArray,
-    Vec2iArray,
+    UVec2Array,
     Vec3Array,
+    Mat4Array,
     Vec4,
     Mat4,
 )
@@ -61,7 +62,7 @@ class LDrawScene:
 
 class LDrawSceneInstanced:
     main_model_name: str
-    geometry_world_transforms: dict[tuple[str, int], object]
+    geometry_world_transforms: dict[tuple[str, int], Mat4Array]
     geometry_cache: dict[str, LDrawGeometry]
 
 class LDrawSceneInstancedPoints:

--- a/ldr_tools_py/ldr_tools_py.pyi
+++ b/ldr_tools_py/ldr_tools_py.pyi
@@ -1,0 +1,81 @@
+from .stub_helpers import (
+    IntArray,
+    FloatArray,
+    Vec2iArray,
+    Vec3Array,
+    Vec4,
+    Mat4,
+)
+
+class LDrawNode:
+    name: str
+    transform: Mat4
+    geometry_name: str | None
+    current_color: int
+    children: list[LDrawNode]
+
+class LDrawGeometry:
+    vertices: Vec3Array
+    vertex_indices: IntArray
+    face_start_indices: IntArray
+    face_sizes: IntArray
+    face_colors: IntArray
+    is_face_stud: list[bool]
+    edge_line_indices: Vec2iArray
+    has_grainy_slopes: bool
+
+class LDrawColor:
+    name: str
+    finish_name: str
+    rgba_linear: Vec4
+    speckle_rgba_linear: Vec4 | None
+
+class GeometrySettings:
+    triangulate: bool
+    add_gap_between_parts: bool
+    stud_type: StudType
+    weld_vertices: bool
+    primitive_resolution: PrimitiveResolution
+    scene_scale: float
+
+class StudType:
+    Disabled: StudType
+    Normal: StudType
+    Logo4: StudType
+    HighContrast: StudType
+
+class PrimitiveResolution:
+    Low: PrimitiveResolution
+    Normal: PrimitiveResolution
+    High: PrimitiveResolution
+
+class PointInstances:
+    translations: Vec3Array
+    rotations_axis: Vec3Array
+    rotations_angle: FloatArray
+    scales: Vec3Array
+
+class LDrawScene:
+    root_node: LDrawNode
+    geometry_cache: dict[str, LDrawGeometry]
+
+class LDrawSceneInstanced:
+    main_model_name: str
+    geometry_world_transforms: dict[tuple[str, int], object]
+    geometry_cache: dict[str, LDrawGeometry]
+
+class LDrawSceneInstancedPoints:
+    main_model_name: str
+    geometry_point_instances: dict[tuple[str, int], PointInstances]
+    geometry_cache: dict[str, LDrawGeometry]
+
+def load_file(
+    path: str, ldraw_path: str, additional_paths: list[str], settings: GeometrySettings
+) -> LDrawScene: ...
+def load_file_instanced(
+    path: str, ldraw_path: str, additional_paths: list[str], settings: GeometrySettings
+) -> LDrawSceneInstanced: ...
+def load_file_instanced_points(
+    path: str, ldraw_path: str, additional_paths: list[str], settings: GeometrySettings
+) -> LDrawSceneInstancedPoints: ...
+def load_color_table(ldraw_path: str) -> dict[int, LDrawColor]: ...

--- a/ldr_tools_py/ldr_tools_py.pyi
+++ b/ldr_tools_py/ldr_tools_py.pyi
@@ -1,3 +1,5 @@
+from typing import Final, ClassVar
+
 from .stub_helpers import (
     UIntArray,
     FloatArray,
@@ -40,15 +42,15 @@ class GeometrySettings:
     scene_scale: float
 
 class StudType:
-    Disabled: StudType
-    Normal: StudType
-    Logo4: StudType
-    HighContrast: StudType
+    Disabled: Final[StudType]
+    Normal: Final[StudType]
+    Logo4: Final[StudType]
+    HighContrast: Final[StudType]
 
 class PrimitiveResolution:
-    Low: PrimitiveResolution
-    Normal: PrimitiveResolution
-    High: PrimitiveResolution
+    Low: Final[PrimitiveResolution]
+    Normal: Final[PrimitiveResolution]
+    High: Final[PrimitiveResolution]
 
 class PointInstances:
     translations: Vec3Array

--- a/ldr_tools_py/ldr_tools_py.pyi
+++ b/ldr_tools_py/ldr_tools_py.pyi
@@ -1,5 +1,5 @@
 from .stub_helpers import (
-    IntArray,
+    UIntArray,
     FloatArray,
     Vec2iArray,
     Vec3Array,
@@ -16,12 +16,12 @@ class LDrawNode:
 
 class LDrawGeometry:
     vertices: Vec3Array
-    vertex_indices: IntArray
-    face_start_indices: IntArray
-    face_sizes: IntArray
-    face_colors: IntArray
+    vertex_indices: UIntArray
+    face_start_indices: UIntArray
+    face_sizes: UIntArray
+    face_colors: UIntArray
     is_face_stud: list[bool]
-    edge_line_indices: Vec2iArray
+    edge_line_indices: UVec2Array
     has_grainy_slopes: bool
 
 class LDrawColor:

--- a/ldr_tools_py/stub_helpers.pyi
+++ b/ldr_tools_py/stub_helpers.pyi
@@ -8,15 +8,15 @@ Mat4: TypeAlias = tuple[Vec4, Vec4, Vec4, Vec4]
 
 # T = TypeVar("T")
 # Array1: TypeAlias = np.ndarray[tuple[int], np.dtype[T]]
-# IntArray: TypeAlias = Array1[np.uint32]
+# UIntArray: TypeAlias = Array1[np.uint32]
 # FloatArray: TypeAlias = Array1[np.float32]
-# Vec2iArray: TypeAlias = np.ndarray[tuple[int, Literal[2]], np.dtype[np.uint32]]
+# UVec2Array: TypeAlias = np.ndarray[tuple[int, Literal[2]], np.dtype[np.uint32]]
 # Vec3Array: TypeAlias = np.ndarray[tuple[int, Literal[3]], np.dtype[np.float32]]
 
 # the true types are exactly as described above,
 # but bpy stubs claim that foreach_set does not accept ndarray
 
-class IntArray(Sequence[int], metaclass=ABCMeta):
+class UIntArray(Sequence[int], metaclass=ABCMeta):
     size: Final[int]
 
 class FloatArray(Sequence[float], metaclass=ABCMeta):
@@ -26,6 +26,6 @@ class Vec3Array(ABC):
     shape: Final[tuple[int, Literal[3]]]
     def reshape(self, _: Literal[-1]) -> FloatArray: ...
 
-class Vec2iArray(ABC):
+class UVec2Array(ABC):
     shape: Final[tuple[int, Literal[2]]]
-    def reshape(self, _: Literal[-1]) -> IntArray: ...
+    def reshape(self, _: Literal[-1]) -> UIntArray: ...

--- a/ldr_tools_py/stub_helpers.pyi
+++ b/ldr_tools_py/stub_helpers.pyi
@@ -12,6 +12,7 @@ Mat4: TypeAlias = tuple[Vec4, Vec4, Vec4, Vec4]
 # FloatArray: TypeAlias = Array1[np.float32]
 # UVec2Array: TypeAlias = np.ndarray[tuple[int, Literal[2]], np.dtype[np.uint32]]
 # Vec3Array: TypeAlias = np.ndarray[tuple[int, Literal[3]], np.dtype[np.float32]]
+# Mat4Array: TypeAlias = np.ndarray[tuple[int, Literal[4], Literal[4]], np.dtype[np.float32]]
 
 # the true types are exactly as described above,
 # but bpy stubs claim that foreach_set does not accept ndarray
@@ -29,3 +30,7 @@ class Vec3Array(ABC):
 class UVec2Array(ABC):
     shape: Final[tuple[int, Literal[2]]]
     def reshape(self, _: Literal[-1]) -> UIntArray: ...
+
+class Mat4Array(ABC):
+    shape: Final[tuple[int, Literal[4], Literal[4]]]
+    def reshape(self, _: Literal[-1]) -> FloatArray: ...

--- a/ldr_tools_py/stub_helpers.pyi
+++ b/ldr_tools_py/stub_helpers.pyi
@@ -1,0 +1,31 @@
+from typing import TypeAlias, Sequence, Literal, Final
+from abc import ABCMeta, ABC
+
+import numpy as np
+
+Vec4: TypeAlias = tuple[float, float, float, float]
+Mat4: TypeAlias = tuple[Vec4, Vec4, Vec4, Vec4]
+
+# T = TypeVar("T")
+# Array1: TypeAlias = np.ndarray[tuple[int], np.dtype[T]]
+# IntArray: TypeAlias = Array1[np.uint32]
+# FloatArray: TypeAlias = Array1[np.float32]
+# Vec2iArray: TypeAlias = np.ndarray[tuple[int, Literal[2]], np.dtype[np.uint32]]
+# Vec3Array: TypeAlias = np.ndarray[tuple[int, Literal[3]], np.dtype[np.float32]]
+
+# the true types are exactly as described above,
+# but bpy stubs claim that foreach_set does not accept ndarray
+
+class IntArray(Sequence[int], metaclass=ABCMeta):
+    size: Final[int]
+
+class FloatArray(Sequence[float], metaclass=ABCMeta):
+    size: Final[int]
+
+class Vec3Array(ABC):
+    shape: Final[tuple[int, Literal[3]]]
+    def reshape(self, _: Literal[-1]) -> FloatArray: ...
+
+class Vec2iArray(ABC):
+    shape: Final[tuple[int, Literal[2]]]
+    def reshape(self, _: Literal[-1]) -> IntArray: ...

--- a/ldr_tools_py/stub_helpers.pyi
+++ b/ldr_tools_py/stub_helpers.pyi
@@ -1,4 +1,4 @@
-from typing import TypeAlias, Sequence, Literal, Final
+from typing import TypeVar, TypeAlias, Literal
 from abc import ABCMeta, ABC
 
 import numpy as np
@@ -6,31 +6,10 @@ import numpy as np
 Vec4: TypeAlias = tuple[float, float, float, float]
 Mat4: TypeAlias = tuple[Vec4, Vec4, Vec4, Vec4]
 
-# T = TypeVar("T")
-# Array1: TypeAlias = np.ndarray[tuple[int], np.dtype[T]]
-# UIntArray: TypeAlias = Array1[np.uint32]
-# FloatArray: TypeAlias = Array1[np.float32]
-# UVec2Array: TypeAlias = np.ndarray[tuple[int, Literal[2]], np.dtype[np.uint32]]
-# Vec3Array: TypeAlias = np.ndarray[tuple[int, Literal[3]], np.dtype[np.float32]]
-# Mat4Array: TypeAlias = np.ndarray[tuple[int, Literal[4], Literal[4]], np.dtype[np.float32]]
-
-# the true types are exactly as described above,
-# but bpy stubs claim that foreach_set does not accept ndarray
-
-class UIntArray(Sequence[int], metaclass=ABCMeta):
-    size: Final[int]
-
-class FloatArray(Sequence[float], metaclass=ABCMeta):
-    size: Final[int]
-
-class Vec3Array(ABC):
-    shape: Final[tuple[int, Literal[3]]]
-    def reshape(self, _: Literal[-1]) -> FloatArray: ...
-
-class UVec2Array(ABC):
-    shape: Final[tuple[int, Literal[2]]]
-    def reshape(self, _: Literal[-1]) -> UIntArray: ...
-
-class Mat4Array(ABC):
-    shape: Final[tuple[int, Literal[4], Literal[4]]]
-    def reshape(self, _: Literal[-1]) -> FloatArray: ...
+T = TypeVar("T")
+Array1: TypeAlias = np.ndarray[tuple[int], np.dtype[T]]
+UIntArray: TypeAlias = Array1[np.uint32]
+FloatArray: TypeAlias = Array1[np.float32]
+UVec2Array: TypeAlias = np.ndarray[tuple[int, Literal[2]], np.dtype[np.uint32]]
+Vec3Array: TypeAlias = np.ndarray[tuple[int, Literal[3]], np.dtype[np.float32]]
+Mat4Array: TypeAlias = np.ndarray[tuple[int, Literal[4], Literal[4]], np.dtype[np.float32]]


### PR DESCRIPTION
Self-explanatory.

I don't know what's going on with the imports - this was the only approach I could find that satisfied mypy while also actually working at runtime, other than putting the `.pyi` file in `ldr_tools_blender`, contrary to PyO3's recommendations.
There's probably a better way, and I wouldn't be surprised if it involves bundling the compiled library in a slightly different fashion.