### PR TITLE
Configurable scaling

### DIFF
--- a/ldr_tools_blender/importldr.py
+++ b/ldr_tools_blender/importldr.py
@@ -59,16 +59,19 @@ def import_objects(
     # Create an object for each part in the scene.
     # This still uses instances the mesh data blocks for reduced memory usage.
     blender_mesh_cache = {}
+
+    # Don't scale any coordinates on the Rust side, just change the scale of the parent object
+    scale = settings.scene_scale
+    settings.scene_scale = 1.0
+
     scene = ldr_tools_py.load_file(filepath, ldraw_path, additional_paths, settings)
 
     root_obj = add_nodes(
         scene.root_node, scene.geometry_cache, blender_mesh_cache, color_by_code
     )
     # Account for Blender having a different coordinate system.
-    # Apply a scene scale to match the previous version.
-    # TODO: make scene scale configurable.
     root_obj.rotation_euler = mathutils.Euler((math.radians(-90.0), 0.0, 0.0), "XYZ")
-    root_obj.scale = (0.01, 0.01, 0.01)
+    root_obj.scale = (scale, scale, scale)
 
 
 def add_nodes(
@@ -118,6 +121,9 @@ def import_instanced(
     color_by_code: dict[int, LDrawColor],
     settings: GeometrySettings,
 ):
+    scale = settings.scene_scale
+    settings.scene_scale = 1.0
+
     # Instance each part on the points of a mesh.
     # This avoids overhead from object creation for large scenes.
     scene = ldr_tools_py.load_file_instanced_points(
@@ -135,9 +141,8 @@ def import_instanced(
 
     root_obj = bpy.data.objects.new(scene.main_model_name, None)
     # Account for Blender having a different coordinate system.
-    # TODO: make scene scale configurable.
     root_obj.rotation_euler = mathutils.Euler((math.radians(-90.0), 0.0, 0.0), "XYZ")
-    root_obj.scale = (0.01, 0.01, 0.01)
+    root_obj.scale = (scale, scale, scale)
     bpy.context.collection.objects.link(root_obj)
 
     # Instant each unique colored part on the faces of a mesh.

--- a/ldr_tools_blender/importldr.py
+++ b/ldr_tools_blender/importldr.py
@@ -11,8 +11,12 @@ from bpy.types import (
     NodeGroupInput,
     NodeGroupOutput,
     GeometryNodeObjectInfo,
+    GeometryNodeSelfObject,
     GeometryNodeInputNamedAttribute,
     GeometryNodeInstanceOnPoints,
+    GeometryNodeStoreNamedAttribute,
+    GeometryNodeRealizeInstances,
+    ShaderNodeVectorMath,
     FunctionNodeAxisAngleToRotation,
 )
 
@@ -96,6 +100,8 @@ def add_nodes(
         else:
             # Use an existing mesh data block like with linked duplicates (alt+d).
             obj = bpy.data.objects.new(node.name, blender_mesh)
+
+        create_geometry_node_standard(obj)
     else:
         # Create an empty by setting the data to None.
         obj = bpy.data.objects.new(node.name, None)
@@ -231,9 +237,27 @@ def create_geometry_node_instancing(
         },
     )
 
-    group_output = graph.node(
-        NodeGroupOutput, location=(0, 0), inputs=[instance_points]
+    realize = graph.node(
+        GeometryNodeRealizeInstances, location=(-20, 0), inputs=[instance_points]
     )
+
+    instance_scale = graph.node(
+        ShaderNodeVectorMath,
+        location=(-20, -180),
+        operation="MULTIPLY",
+        inputs=[instance_info["Scale"], scale_attribute],
+    )
+
+    # Copy the part scale from instancing to geometry for use in shaders
+    store_scale = graph.node(
+        GeometryNodeStoreNamedAttribute,
+        location=(170, 0),
+        data_type="FLOAT_VECTOR",
+        domain="FACE",
+        inputs={"Geometry": realize, "Value": instance_scale, "Name": "scale"},
+    )
+
+    group_output = graph.node(NodeGroupOutput, location=(360, 0), inputs=[store_scale])
 
 
 def create_instancer_mesh(name: str, instances: ldr_tools_py.PointInstances):
@@ -356,3 +380,46 @@ def create_mesh_from_geometry(name: str, geometry: LDrawGeometry):
             is_stud.data.foreach_set("value", geometry.is_face_stud)
 
     return mesh
+
+
+def create_geometry_node_standard(obj: bpy.types.Object) -> None:
+    modifier = obj.modifiers.new("Store Scale Attribute", "NODES")
+    assert isinstance(modifier, NodesModifier)
+
+    if existing := bpy.data.node_groups.get("Store Scale Attribute"):
+        assert isinstance(existing, GeometryNodeTree)
+        modifier.node_group = existing
+        return
+
+    tree = bpy.data.node_groups.new("Store Scale Attribute", "GeometryNodeTree")  # type: ignore[arg-type]
+    assert isinstance(tree, GeometryNodeTree)
+    modifier.node_group = tree
+
+    graph = NodeGraph(tree)
+
+    graph.input(NodeSocketGeometry, "Geometry")
+    graph.output(NodeSocketGeometry, "Geometry")
+
+    group_input = graph.node(NodeGroupInput, location=(-360, 30))
+
+    self_object = graph.node(GeometryNodeSelfObject, location=(-570, -110))
+
+    object_info = graph.node(
+        GeometryNodeObjectInfo,
+        location=(-360, -110),
+        inputs=[self_object],
+    )
+
+    store_attribute = graph.node(
+        GeometryNodeStoreNamedAttribute,
+        location=(-150, 30),
+        data_type="FLOAT_VECTOR",
+        domain="FACE",
+        inputs={
+            "Geometry": group_input,
+            "Value": object_info["Scale"],
+            "Name": "scale",
+        },
+    )
+
+    graph.node(NodeGroupOutput, location=(60, 30), inputs=[store_attribute])

--- a/ldr_tools_blender/material.py
+++ b/ldr_tools_blender/material.py
@@ -167,9 +167,7 @@ def get_material(
         )
 
         slope_normals = graph.node(
-            ShaderNodeGroup,
-            location=(-630, 100),
-            node_tree=slope_normals_node_group(),
+            ShaderNodeGroup, location=(-630, 100), node_tree=slope_normals_node_group()
         )
 
         # Choose between grainy and smooth normals depending on the face.

--- a/ldr_tools_blender/operator.py
+++ b/ldr_tools_blender/operator.py
@@ -1,7 +1,7 @@
 import os
 import json
 import bpy
-from bpy.props import StringProperty, EnumProperty, BoolProperty
+from bpy.props import StringProperty, EnumProperty, BoolProperty, FloatProperty
 from bpy_extras.io_utils import ImportHelper
 import typing
 from typing import Any
@@ -68,6 +68,8 @@ class Preferences:
         self.primitive_resolution = "Normal"
         self.additional_paths = []
         self.add_gap_between_parts = True
+        # default matches hardcoded behavior of previous versions
+        self.scene_scale = 0.01
 
     def from_dict(self, dict: dict[str, Any]):
         # Fill in defaults for any missing values.
@@ -82,6 +84,7 @@ class Preferences:
         self.add_gap_between_parts = dict.get(
             "add_gap_between_parts", defaults.add_gap_between_parts
         )
+        self.scene_scale = dict.get("scene_scale", defaults.scene_scale)
 
     def save(self):
         with open(Preferences.preferences_path, "w+") as file:
@@ -196,6 +199,12 @@ class ImportOperator(bpy.types.Operator, ImportHelper):
         default=preferences.add_gap_between_parts,
     )
 
+    scene_scale: FloatProperty(
+        name="Scale",
+        description="Scale factor for the imported model",
+        default=preferences.scene_scale,
+    )
+
     def draw(self, context):
         layout = self.layout
         layout.use_property_split = True
@@ -204,6 +213,7 @@ class ImportOperator(bpy.types.Operator, ImportHelper):
         layout.prop(self, "stud_type")
         layout.prop(self, "primitive_resolution")
         layout.prop(self, "add_gap_between_parts")
+        layout.prop(self, "scene_scale")
 
         # TODO: File selector?
         # TODO: Come up with better UI for this?
@@ -224,6 +234,7 @@ class ImportOperator(bpy.types.Operator, ImportHelper):
         ImportOperator.preferences.stud_type = self.stud_type
         ImportOperator.preferences.primitive_resolution = self.primitive_resolution
         ImportOperator.preferences.add_gap_between_parts = self.add_gap_between_parts
+        ImportOperator.preferences.scene_scale = self.scene_scale
 
         settings = self.get_settings()
 
@@ -266,7 +277,7 @@ class ImportOperator(bpy.types.Operator, ImportHelper):
         elif self.primitive_resolution == "High":
             settings.primitive_resolution = ldr_tools_py.PrimitiveResolution.High
 
-        settings.scene_scale = 1.0
+        settings.scene_scale = self.scene_scale
         # Required for calculated normals.
         settings.weld_vertices = True
 


### PR DESCRIPTION
#17

This approach has the advantage of working as expected if you import two models into the same project at different scales. Not sure why you'd want to do that, but it's still a nice lack of jank.

I spent several hours figuring out the best way to expose the object scale as an attribute (in a way that would work with both import modes), only to discover the `ShaderNodeVectorTransform` trick.

Noise textures seem to already scale with the object.